### PR TITLE
pg_pool Connection retry untill connection establish.

### DIFF
--- a/emqx.conf
+++ b/emqx.conf
@@ -31,3 +31,14 @@ retainer {
         storage_type = disc
     }
 }
+plugins {
+    states = [
+        {
+         
+            name_vsn = "mqtt2pgsql-1.0.0",
+
+            enable = true
+        }
+    ]
+    install_dir = "plugins"
+}

--- a/rebar.config
+++ b/rebar.config
@@ -8,6 +8,7 @@
     , {emqx_durable_storage, {git_subdir, "https://github.com/emqx/emqx.git", {tag, "v5.4.1"}, "apps/emqx_durable_storage"}}
     , {epgsql, {git, "https://github.com/epgsql/epgsql.git", {tag, "4.7.1"}}}
     , {map_sets, "1.1.0"}
+    , {poolboy, ">= 1.5.2"}
     ]}.
 
 {plugins, [

--- a/src/mqtt2pgsql_psql_pool_worker.erl
+++ b/src/mqtt2pgsql_psql_pool_worker.erl
@@ -13,7 +13,7 @@ start_link(Args) ->
 
 init(Args) ->
     process_flag(trap_exit, true),
-     start_connection_loop(Args).
+    start_connection_loop(Args).
 
 start_connection_loop(Args) ->
     Hostname = proplists:get_value(hostname, Args),

--- a/src/mqtt2pgsql_psql_pool_worker.erl
+++ b/src/mqtt2pgsql_psql_pool_worker.erl
@@ -14,7 +14,7 @@ start_link(Args) ->
 init(Args) ->
     process_flag(trap_exit, true),
     start_connection_loop(Args).
-
+    start_connection_loop(Args).
 start_connection_loop(Args) ->
     Hostname = proplists:get_value(hostname, Args),
     Database = proplists:get_value(database, Args),

--- a/src/mqtt2pgsql_psql_pool_worker.erl
+++ b/src/mqtt2pgsql_psql_pool_worker.erl
@@ -14,7 +14,7 @@ start_link(Args) ->
 init(Args) ->
     process_flag(trap_exit, true),
     start_connection_loop(Args).
-    start_connection_loop(Args).
+
 start_connection_loop(Args) ->
     Hostname = proplists:get_value(hostname, Args),
     Database = proplists:get_value(database, Args),

--- a/src/mqtt2pgsql_psql_pool_worker.erl
+++ b/src/mqtt2pgsql_psql_pool_worker.erl
@@ -13,6 +13,9 @@ start_link(Args) ->
 
 init(Args) ->
     process_flag(trap_exit, true),
+     start_connection_loop(Args).
+
+start_connection_loop(Args) ->
     Hostname = proplists:get_value(hostname, Args),
     Database = proplists:get_value(database, Args),
     Username = proplists:get_value(username, Args),
@@ -25,7 +28,8 @@ init(Args) ->
             {ok, #state{conn=Conn}};
         {error, Reason} ->
             io:format("Error connecting to the database: ~p~n", [Reason]),
-            {error, Reason}
+            timer:sleep(5000),
+            start_connection_loop(Args)
     end.
 
 


### PR DESCRIPTION
## BUG
After the mqtt2pgsql plugin starts, if the connected pgsql service was stopped or the pgsql connection limit is reached, the plugin throws an error and crashed.


![pg_pool](https://github.com/arvindh123/mqtt2pgsql/assets/114956287/cabfdf5d-15ff-402c-ba09-5825bacb1ba4)


## FIX:
On pg_pool_worker Handled the pgsql connection error and trying to reconnect the pgsql connection until the connection was established.